### PR TITLE
Add automatic connection resetting

### DIFF
--- a/config-example.js
+++ b/config-example.js
@@ -53,6 +53,11 @@ exports.watchconfig = false;
 // doesn't support that yet, so it's best to leave this empty.
 exports.secprotocols = [];
 
+// Time in minutes the bot can go without receiving a chat message before resetting.
+// Refreshes the websocket connection in case it drops without a closing handshake.
+// Leave blank or 0 if you do not wish for the bot to refresh it's own connection.
+exports.resetduration = 0;
+
 // What should be logged?
 // 0 = error, ok, info, debug, recv, send
 // 1 = error, ok, info, debug, cmdr, send

--- a/parser.js
+++ b/parser.js
@@ -341,6 +341,11 @@ exports.parse = {
 		var userData = this.chatData[user];
 		if (!this.chatData[user][room]) this.chatData[user][room] = {times:[], points:0, lastAction:0};
 		var roomData = userData[room];
+		
+		if (config.resetduration) {
+			clearTimeout(global.connectionTimer);
+			refreshConnectionTimer();
+		}
 
 		// this deals with punishing rulebreakers, but note that the bot can't think, so it might make mistakes
 		if (config.allowmute && this.hasRank(this.ranks[room] || ' ', '%@&#~') && config.whitelist.indexOf(user) === -1) {


### PR DESCRIPTION
Uses a configurable timer to reset the bot in the event that it gets
disconnected without the server sending a closing message. Though
resetting it's own connection is a bit slow at times, this ensures that
the bot will NEVER have to be manually reset to keep it online.